### PR TITLE
fix gtest build error

### DIFF
--- a/src/route_test.cpp
+++ b/src/route_test.cpp
@@ -72,7 +72,7 @@ TEST(route_tests, initialization) {
   Route route;
   nav_msgs::msg::Path path = get_simple_test_path();
   route.set_path(path);
-  ASSERT_EQ(route.nodes.size(), 3);
+  ASSERT_EQ(route.nodes.size(), 3U);
 }
 
 TEST(route_tests, traverse_route) {
@@ -91,38 +91,38 @@ TEST(route_tests, traverse_route) {
   route_position->set_position({0, 0});
 
   // start route
-  ASSERT_EQ(route_position->index, 0);
+  ASSERT_EQ(route_position->index, 0U);
   ASSERT_EQ(route_position->cte, 0.0);
   ASSERT_EQ(route_position->progress, 0.0);
   ASSERT_NEAR(route.get_velocity(*route_position),  velocity_at_position(2.0, 1.0, 0.0), tolerance);
 
   // move along first segment with a little error above
   route_position->set_position({0.5, 0.1});
-  ASSERT_EQ(route_position->index, 0);
+  ASSERT_EQ(route_position->index, 0U);
   ASSERT_EQ(route_position->cte, -0.1);
   ASSERT_EQ(route_position->progress, 0.5);
 
   // move further along first segment with a little error below
   route_position->set_position({0.6, -0.1});
-  ASSERT_EQ(route_position->index, 0);
+  ASSERT_EQ(route_position->index, 0U);
   ASSERT_EQ(route_position->cte, 0.1);
   ASSERT_EQ(route_position->progress, 0.6);
 
   // move past first segment, below second
   route_position->set_position({2.0, 0.0});
-  ASSERT_EQ(route_position->index, 1.0);
+  ASSERT_EQ(route_position->index, 1U);
   ASSERT_NEAR (route_position->cte, sqrt(2)/2.0, tolerance);
   ASSERT_EQ(route_position->progress, 0.5);
 
   // move further along second segment, no error
   route_position->set_position({1.9, 0.9});
-  ASSERT_EQ(route_position->index, 1);
+  ASSERT_EQ(route_position->index, 1U);
   ASSERT_NEAR (route_position->cte, 0.0, tolerance);
   ASSERT_NEAR(route_position->progress, 0.9, tolerance);
 
   // move past end of route
   route_position->set_position({2.1, 1.1});
-  ASSERT_EQ(route_position->index, 1);
+  ASSERT_EQ(route_position->index, 1U);
   ASSERT_EQ(route_position->done, true);
   ASSERT_NEAR (route_position->cte, 0.0, tolerance);
   ASSERT_NEAR(route_position->progress, 1.1, tolerance);


### PR DESCRIPTION
Warnings in gtest test cases. Because of them build fails.

```
[Processing: nav2_line_following_controller]                             
--- stderr: nav2_line_following_controller                               
In file included from /home/ros-humble-desktop/ackermann_test/src/nav2_line_following_controller/src/route_test.cpp:2:
/opt/ros/humble/src/gtest_vendor/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
/opt/ros/humble/src/gtest_vendor/include/gtest/gtest.h:1554:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; typename std::enable_if<((! std::is_integral<_Tp>::value) || (! std::is_pointer<_Dp>::value))>::type* <anonymous> = 0]’
/home/ros-humble-desktop/ackermann_test/src/nav2_line_following_controller/src/route_test.cpp:75:3:   required from here
/opt/ros/humble/src/gtest_vendor/include/gtest/gtest.h:1527:11: error: comparison of integer expressions of different signedness: ‘const long unsigned int’ and ‘const int’ [-Werror=sign-compare]
 1527 |   if (lhs == rhs) {
      |       ~~~~^~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/route_test.dir/build.make:76: CMakeFiles/route_test.dir/src/route_test.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:213: CMakeFiles/route_test.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< nav2_line_following_controller [44.3s, exited with code 2]
```